### PR TITLE
Update get_grid.R

### DIFF
--- a/R/get_grid.R
+++ b/R/get_grid.R
@@ -67,11 +67,8 @@ get_grid <- function(boundary, resolution = 5000, crs, output = "raster", touche
                        field = 1)
 
   } else{
-    grid_out <- if(output == "sf_square") sf::st_make_grid(boundary, cellsize = resolution, square = TRUE) |> sf::st_sf() else sf::st_make_grid(boundary, cellsize = resolution, square = FALSE) |> sf::st_sf()
-
 
     grid_out <- sf::st_make_grid(boundary, cellsize = resolution, square = (output == "sf_square"))
-
 
     if (touches){
       grid_intersect <- grid_out

--- a/R/get_grid.R
+++ b/R/get_grid.R
@@ -92,7 +92,7 @@ get_grid <- function(boundary, resolution = 5000, crs, output = "raster", touche
       round(digits = 4)
 
     grid_out[order(grid_xy[,"Y"], grid_xy[,"X"], decreasing = c(TRUE, FALSE)),] |>
-      sf::st_as_sf()
+      sf::st_sf(geometry = _)
 
   }
 }


### PR DESCRIPTION
Small fix to ensure the geometry column is called `geometry` and not `x` for the planning units in `get_grid`. This is consistent with oceandatr which always returns `geometry`. 

All checks still pass.

Also fix a smaller error in second commit